### PR TITLE
Update plugins and .infz file. Fix plugin naming

### DIFF
--- a/update/atak-release.apk
+++ b/update/atak-release.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffd4cffc606503c2e9c93161d809a4ed7eb8f4b065f87281a3392a145df1ca43
-size 99273893

--- a/update/atak_app.apk
+++ b/update/atak_app.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c14427910fb88605b4256123e7e9b52cab7c8cde2a2e6f4d8444c1543d90fd51
+size 99273893

--- a/update/data_sync_plugin.apk
+++ b/update/data_sync_plugin.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:890c0e6b818b7be7791f00f6e1477038afe4a00241f2ef95ed8f4fb9a64c28e3
+size 4321270

--- a/update/datasync-release.apk
+++ b/update/datasync-release.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:890c0e6b818b7be7791f00f6e1477038afe4a00241f2ef95ed8f4fb9a64c28e3
-size 4321270

--- a/update/product.infz
+++ b/update/product.infz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18a07537da15b83495b0eb158759ca90f538938ddbc3e8677ad6d86ac442e5e1
-size 25222
+oid sha256:3aed8fa20482c6d8eb58af889a24987d20571de507b0544597f1c0fda27bcdae
+size 25289


### PR DESCRIPTION
Update plugins:
ATAK 5.4.0.16
Data Sync 3.5.27

Fix naming to taktool standard