### PR TITLE
Update ATAK distribution to 5.6.0.13

### DIFF
--- a/update/ATAK-5.6.0.13-f93e6a7e-civ-release.apk
+++ b/update/ATAK-5.6.0.13-f93e6a7e-civ-release.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:469068c4d93d06ba8695552b78775a792c70924622ca9366e8a922c5cf40ea2b
+size 364543789

--- a/update/atak-dist-0qplabaj.dpk
+++ b/update/atak-dist-0qplabaj.dpk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa39ab8558d020c46ec3b26011a488c0e22e93a11c071258a9f809596d0b0ba8
+size 357085890

--- a/update/atak_app.apk
+++ b/update/atak_app.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed45485510832f208f859fb0a4ea53732c8a0b9dac524374f0cfbebfbf3509bb
-size 107889857

--- a/update/data_sync_plugin.apk
+++ b/update/data_sync_plugin.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d785c5819d727796e56fcd0124bfd67dcbc8e53de9cc1ac0545601c1a17d54a0
-size 4333558

--- a/update/opentak_icu_app.apk
+++ b/update/opentak_icu_app.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6246878c7188c642ff50558b5aee030c6364ece47b52f0abae3f4bb3c9aa6028
-size 20965070

--- a/update/product.infz
+++ b/update/product.infz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4649632dcd4267b3573ebc08b6b2ca35c2694524792a78ab21594511d78d5664
-size 41816

--- a/update/vns_plugin.apk
+++ b/update/vns_plugin.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f817023441f69aebb87c826f86701111c9c8c49a85111de6384c646bdf7f828
-size 5170853


### PR DESCRIPTION
Automated ATAK distribution update.

**ATAK version:** 5.6.0.13
**Product file:** `ATAK-5.6.0.13-f93e6a7e-civ-release.apk`
