### PR TITLE
Json logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # So work around like this                                             #
 ########################################################################
 ARG TEMURIN_VERSION="17"
-ARG TAK_RELEASE="5.5-RELEASE-58"
+ARG TAK_RELEASE="5.6-RELEASE-20"
 FROM pvarki/tak-server-dist:$TAK_RELEASE AS tak-files
 RUN mv /zips/takserver-docker-*.zip /tmp/takserver.zip
 

--- a/README.rst
+++ b/README.rst
@@ -10,17 +10,18 @@ tldr::
     docker compose pull --include-deps --ignore-pull-failures
     docker compose -p tak up -d
 
-or use docker compose.local.yml without gomplate for local dev (rebuilding containers)::
+
+or if you want to first build locally to test changes use the compose build so that the local image is used instead:
 
     export DOCKER_TAG_EXTRA="-dev"
-    docker build --no-cache --progress=plain -t takserver:latest${DOCKER_TAG_EXTRA} -t takserver:4.7-RELEASE-32${DOCKER_TAG_EXTRA} -t pvarki/takserver:4.7-RELEASE-32${DOCKER_TAG_EXTRA} .
+    docker compose -f docker-compose.yml -p tak build
     cp takserver.env.example takserver.env
     # edit the env
-    docker compose -f docker-compose.local.yml -p tak up
+    docker compose -f docker-compose.yml -p tak up
 
 Note, for things that live in the volumes (like TAK certs) you must nuke the volumes to see changes::
 
-    docker compose -f docker-compose.local.yml -p tak down -v ; docker compose -f docker-compose.local.yml -p tak rm -vf
+    docker compose -f docker-compose.yml -p tak down -v ; docker compose -f docker-compose.yml -p tak rm -vf
 
 
 

--- a/scripts/start-tak.sh
+++ b/scripts/start-tak.sh
@@ -24,6 +24,9 @@ ln -sf ${IGNITE_CONFIG_PATH} ${TR}/TAKIgniteConfig.xml
 ls -lah ${TR}/TAKIgniteConfig.xml
 cat ${TR}/TAKIgniteConfig.xml
 
+echo "Ensuring our logging config is in place (Logback)"
+cp /opt/templates/logback-stdout.xml /opt/tak/
+
 set +x
 
 # Ensure anything not having the correct config loads certs and saves logs to the volume

--- a/takserver.env.example
+++ b/takserver.env.example
@@ -28,3 +28,8 @@ POSTGRES_ADDRESS=takdb
 # With the default composition the user is the superuser but in other cases it isn't
 POSTGRES_SUPERUSER=$POSTGRES_USER
 POSTGRES_SUPER_PASSWORD=$POSTGRES_PASSWORD
+
+# Turn on JSON based logging
+LOGGING_JSON_ENABLED=true
+# Use our own logback config to foward json also into STDOUT for container log collection
+LOGGING_CONFIG=/opt/tak/logback-stdout.xml

--- a/templates/CoreConfig.tpl
+++ b/templates/CoreConfig.tpl
@@ -72,4 +72,11 @@
             enableOCSP="{{getenv "TAK_OCSP_ENABLE" "false"}}"
             />
     </security>
+
+    <logging
+        auditLoggingEnabled="true"
+        httpAccessEnabled="true"
+        jsonFormatEnabled="true"
+    />
+
 </Configuration>

--- a/templates/logback-stdout.xml
+++ b/templates/logback-stdout.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.JsonEncoder"/>
+    </appender>
+
+    <!-- =========================================================
+         AUDIT LOGGERS
+         Requires CoreConfig.tpl: <logging auditLoggingEnabled="true" httpAccessEnabled="true"/>
+         MDC fields included automatically by JsonEncoder:
+           username, roles, source-ip, session, method,
+           request-body, response-status, response-body
+         ========================================================= -->
+
+    <!-- HTTP audit: full request context per API call -->
+    <logger name="com.bbn.marti.util.spring.MissionRoleAssignmentRequestHolderFilterBean" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <!-- HTTP access: one line per request -->
+    <logger name="http_access_logger" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <!-- Security violations (ESAPI intrusion detection) -->
+    <logger name="IntrusionDetector" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <!-- SQL audit: disabled by default - extremely verbose (every query).
+         Enable only for targeted debugging by setting level to TRACE.
+    <logger name="data-access-log" level="TRACE" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+    -->
+
+    <!-- =========================================================
+         NOISE SUPPRESSION
+         Preserved from bundled logback-spring.xml (takserver.war)
+         and logback.xml (takserver-retention.jar, takserver-pm.jar)
+         ========================================================= -->
+
+    <!-- Ignite: suppress everything below ERROR across all services -->
+    <logger name="org.apache.ignite" level="ERROR"/>
+
+    <!-- Spring -->
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.springframework.web.socket.config.WebSocketMessageBrokerStats" level="OFF"/>
+    <logger name="org.springframework.security.config.http.FilterInvocationSecurityMetadataSourceParser" level="OFF"/>
+    <logger name="org.springframework.boot.autoconfigure.orm.jpa" level="OFF"/>
+    <logger name="org.springframework.boot.actuate.endpoint.EndpointId" level="OFF"/>
+    <logger name="org.springframework.http" level="OFF"/>
+    <logger name="org.springframework.web" level="OFF"/>
+    <logger name="org.springframework.core" level="OFF"/>
+    <logger name="org.springframework.security.core.SpringSecurityCoreVersion" level="OFF"/>
+
+    <!-- Hibernate -->
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="OFF"/>
+    <logger name="org.hibernate.SQL" level="WARN" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+    <logger name="org.hibernate.type" level="WARN" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <!-- Tomcat -->
+    <logger name="org.apache.tomcat.util.net.NioEndpoint" level="OFF"/>
+    <logger name="org.apache.tomcat.util.net" level="OFF"/>
+    <logger name="org.apache" level="WARN"/>
+
+    <!-- gRPC -->
+    <logger name="io.grpc.internal.SerializingExecutor" level="OFF"/>
+
+    <!-- Swagger/SpringFox -->
+    <logger name="springfox" level="OFF"/>
+
+    <!-- Connection pool -->
+    <logger name="com.zaxxer" level="WARN"/>
+
+    <!-- TAK internal: suppress noisy data access audit wrapper -->
+    <logger name="data-access-log" level="OFF"/>
+
+    <!-- TAK internal: reduce noise from large upload servlet -->
+    <logger name="com.bbn.marti.sync.MissionPackageUploadServlet" level="WARN"/>
+
+    <!-- =========================================================
+         SIGNAL LOGGERS
+         Keep these visible so startup and health are observable
+         ========================================================= -->
+    <logger name="tak.server.ServerConfiguration" level="INFO"/>
+    <logger name="org.springframework.boot.web.embedded.tomcat.TomcatWebServer" level="INFO"/>
+    <logger name="metrics-logger" level="INFO"/>
+
+    <!-- =========================================================
+         ROOT
+         ========================================================= -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
JSON logging support to generate structure logs for Elastic Stack usage
This version customizes the TAK server config in several ways:
  * Enabled the build in mechanisms to doing JSON based logging in the CoreConfig.xml file
  * As HTTP Access logs were not by default coming to STDOUT forked also the logback.xml config to manage all logging
    * This now allows us to control what logs are send to containers STDOUT
  * Also uses the standard Spring environment variables to enable JSON logs
  * Disables log files on disk (can be added back if needed)