### PR TITLE
Update server distribution to 5.7-32

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.3.0+260512"
+current_version = "5.7.32+260523"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/build_compose.yml
+++ b/build_compose.yml
@@ -107,11 +107,11 @@ services:
         TAK_RELEASE: "20"
 
   v570:
-    image: pvarki/tak-server-dist:5.7-RELEASE-8
+    image: pvarki/tak-server-dist:5.7-RELEASE-32
     build:
       context: .
       dockerfile: Dockerfile_build
       target: takgov_files
       args:
         TAK_VERSION: "5.7"
-        TAK_RELEASE: "8"
+        TAK_RELEASE: "32"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 x-takbuilds: &takbuildinfo
-  image: "${PVARKI_DOCKER_REPO:-ghcr.io/}pvarki/takserver:${TAK_RELEASE:-5.7-RELEASE-8}${DOCKER_TAG_EXTRA:-}"
+  image: "${PVARKI_DOCKER_REPO:-ghcr.io/}pvarki/takserver:${TAK_RELEASE:-5.7-RELEASE-32}${DOCKER_TAG_EXTRA:-}"
   build:
     context: .
     dockerfile: Dockerfile
     args:
-        TAK_RELEASE: ${TAK_RELEASE:-5.7-RELEASE-8}
+        TAK_RELEASE: ${TAK_RELEASE:-5.7-RELEASE-32}
 
 services:
 


### PR DESCRIPTION
## User-facing summary

Takserver 5.7-32 update.

- Fixes to Mission API, Federation and API.
- Bug fixes to KML Elevation data.
- Security updates to CVE's.

## Why It's Good for the Product (Release Goal)

Improved security & functionality.