### PR TITLE
Update ATAK distribution to 5.6.0.18

### DIFF
--- a/update/atak_app.apk
+++ b/update/atak_app.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f304525cc36040e4edb09f46147b966add7349e83e87287d4c6e8d45955d169
+size 108197057

--- a/update/data_sync_plugin.apk
+++ b/update/data_sync_plugin.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d785c5819d727796e56fcd0124bfd67dcbc8e53de9cc1ac0545601c1a17d54a0
+size 4333558

--- a/update/opentak_icu_app.apk
+++ b/update/opentak_icu_app.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4fda99d4990d5b570a1b33f4c979094b7446cf63e4f9894dcdfca151c288f3f
+size 28111640

--- a/update/product.infz
+++ b/update/product.infz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55259a3adcb835b91589781832fcb2c77d4590eba78dc5dd70300529a2aeedd6
+size 29652

--- a/update/repositories.inf
+++ b/update/repositories.inf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08f0a21c96d400af615075122b20149b28888e8c70b4d42c8c63517854118f96
-size 12

--- a/update/repository.inf
+++ b/update/repository.inf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08f0a21c96d400af615075122b20149b28888e8c70b4d42c8c63517854118f96
-size 12

--- a/update/vns_plugin.apk
+++ b/update/vns_plugin.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f817023441f69aebb87c826f86701111c9c8c49a85111de6384c646bdf7f828
+size 5170853


### PR DESCRIPTION
Automated ATAK distribution update.

**ATAK version:** 5.6.0.18
**Product file:** `ATAK-5.6.0.18-f4cee7b9-civSmall-release.apk`

**Plugins:**
- datasync v3.7.4 (ATAK 5.6.0)
- opentak-icu v1.6.0 (ATAK )
- vns v4.0 (ATAK 5.6.0)
