### PR TITLE
Update ATAK distribution to 5.7.0.5

### DIFF
--- a/update/5.7.0/atak_app.apk
+++ b/update/5.7.0/atak_app.apk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f2bc0f215ccfdc6d598c1967a48b2cf71da88c66ccc5442d6b44c9e2b159f43
+oid sha256:ba9b3cdf38c913c98f35e6ee4674bcf29a922c7dd0769e0ed14697b6507ff329
 size 111740603

--- a/update/5.7.0/data_sync_plugin.apk
+++ b/update/5.7.0/data_sync_plugin.apk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4bb7a9ad3f1a997cf8b00e374cbee79d2ddb2d66419ddcd3c90f04317f345a45
+oid sha256:e86f54401448448a1d0a1fc8e55aa5f4ed7396f2455a4e369e74611252b93fad
 size 4329406

--- a/update/5.7.0/product.infz
+++ b/update/5.7.0/product.infz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:08820425976563e3cc3783aaf3df21889277fb55bd21d1dc2ca9bd876cb28bb3
-size 41812
+oid sha256:b9df8a1db4604c0ac7e31c0101647bd36ec80d6c356b31f1ae488ae5846d8c9e
+size 34333

--- a/update/5.7.0/uas_tool_plugin.apk
+++ b/update/5.7.0/uas_tool_plugin.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c42342c723fdcd9d751f58bb697dd13d75a249b6eab8e4fa92eb9897c4735448
+size 296248798


### PR DESCRIPTION
Automated ATAK distribution update (public-atak-server-5.7).

**ATAK version:** 5.7.0.5
**Product file:** `ATAK-5.7.0.5-3198049e-civSmall-release.apk`

**Plugins:**
- datasync v4.0.4
- vns v4.0
- uastool v13.0.0
- opentak_icu v1.5.4
