### PR TITLE
Update ATAK distribution to 5.6.0.18

### DIFF
--- a/update/5.6.0/atak_app.apk
+++ b/update/5.6.0/atak_app.apk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b57d253fb4badee6ca8bbaf4af3af0b2084cf554eb3521ea24faeba4e696bc0
-size 107893953
+oid sha256:9f304525cc36040e4edb09f46147b966add7349e83e87287d4c6e8d45955d169
+size 108197057

--- a/update/5.6.0/product.infz
+++ b/update/5.6.0/product.infz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37f845ac5d5c2c41ebd5a7a082d0ceefda40c6f64fe71a341c0e81dce44bce6b
-size 41814
+oid sha256:1f111ba452d9ab27ae3f7b736d4b9d0f9fa737675c9b676b217626f1eb33a474
+size 34335

--- a/update/5.6.0/uas_tool_plugin.apk
+++ b/update/5.6.0/uas_tool_plugin.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36f6c837bf73dfbf692e6e0aa115dbf443d3c91483576c9d09e68e81de158948
+size 296248798


### PR DESCRIPTION
Automated ATAK distribution update (public-atak-server-5.6).

**ATAK version:** 5.6.0.18
**Product file:** `ATAK-5.6.0.18-f4cee7b9-civSmall-release.apk`

**Plugins:**
- datasync v3.7.4
- vns v4.0
- uastool v13.0.0
- opentak_icu v1.5.4
