### PR TITLE
DO NOT MERGE: trust the deployment CA in the JVM truststore

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion] # Remember to change the TAK_RELEASE tag in CI jobs as well
-current_version = "5.8.69+260823"
+current_version = "5.8.69+260827"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/scripts/start-tak.sh
+++ b/scripts/start-tak.sh
@@ -40,6 +40,23 @@ if [[ ! -L "${TR}/logs"  ]];then
   ln -s "${TR}/data/logs/" "${TR}/logs"
 fi
 
+# TAK validates every client certificate against the OCSP responder named in its
+# AIA extension, and in this deployment that URL is HTTPS. That call goes through
+# the JVM truststore, not TAK's own truststore, so without the deployment CA in
+# there the responder's TLS certificate is untrusted, the OCSP check throws, and
+# netty rejects every mTLS client with "peer not verified" - nothing wrong with
+# the client certificate at all. Re-applied on every start; the JVM truststore
+# lives in the image layer, not on a volume.
+if [[ -d /ca_public ]];then
+  for pem in /ca_public/*.pem; do
+    grep -q "BEGIN CERTIFICATE" "${pem}" || continue  # /ca_public also holds CRLs
+    ALIAS="ca_public_$(basename "${pem}" .pem)"
+    keytool -cacerts -storepass changeit -delete -alias "${ALIAS}" >/dev/null 2>&1 || true
+    keytool -cacerts -storepass changeit -noprompt -importcert -trustcacerts \
+      -alias "${ALIAS}" -file "${pem}" >/dev/null && echo "JVM now trusts ${pem}"
+  done
+fi
+
 # Change to workdir
 cd ${TR}
 


### PR DESCRIPTION
> Relates to the **BattleLog proof-of-concept test**. **Do not merge** — opened so CI publishes a branch-tagged image for a test server.

## User-Facing Summary

- TAK accepts product client certificates again. Every mTLS client was being refused with `Certificate error: peer not verified`, even with a valid, enrolled certificate in the right group.
- Cause: TAK checks each client certificate against the OCSP responder in its AIA extension, RASENMAEHER serves that over HTTPS, and that call uses the **JVM** truststore rather than `takserver-truststore.jks`. Where the responder is fronted by a private CA the check throws and netty rejects the client.
- `start-tak.sh` now imports every CA in `/ca_public` into the JVM truststore on start, re-applied each start because that truststore lives in the image layer.

## Why It's Good for the Product (Release Goal)

- Unblocks mTLS CoT streams for any product, not just BattleLog.
- Removes a failure that is very hard to diagnose from the client side: the handshake completes and the connection is then dropped, with the real reason only in `takserver-messaging.log`.
- Verified on `rmlocal` with TAK 5.8-RELEASE-69: before, `openssl s_client` with a valid RM certificate got `tlsv1 alert internal error`; after, the handshake completes and TAK sends its version banner.
