### PR TITLE
feat: make TAK federation configurable from the template

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion] # Remember to change the TAK_RELEASE tag in CI jobs as well
-current_version = "5.8.69+260823"
+current_version = "5.8.69+260905"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion] # Remember to change the TAK_RELEASE tag in CI jobs as well
-current_version = "5.8.69+260905"
+current_version = "5.8.69+260907"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,6 +24,10 @@ jobs:
         uses: j178/prek-action@v2
         env:
           SKIP: no-commit-to-branch
+      - name: Test federation-init
+        run: |
+          sudo apt-get update && sudo apt-get install -y libxml2-utils
+          ./tests/federation/test-federation-init.sh
       - name: Validate bumpversion
         uses: pvarki/config-ci-library/.github/actions/validate-bumpversion@main
 

--- a/scripts/federation-init.sh
+++ b/scripts/federation-init.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env -S /bin/bash
+#
+# Build the TAK federation identity keystore, the federation truststore, and the
+# generated <federation> tail that CoreConfig.tpl splices in.
+#
+# ORDERING: run this AFTER firstrun_rm.sh, which seeds fed-truststore.jks with this
+# deployment's own CAs. This script then adds the peer CAs on top and writes the
+# <federation> fragment that CoreConfig.tpl splices in via TAK_FEDERATION_EXTRA_FILE.
+#
+# IDEMPOTENCY: runs on every pod start. Both stores and the XML are rebuilt from
+# scratch, so stale peers cannot accumulate and no `keytool -delete` can trip set -e.
+
+set -euo pipefail
+
+# Overridable so the script can be exercised outside a TAK container (see the test that
+# ships with it); in the image these are the real paths and nothing needs to set them.
+CERT_DIR="${CERT_DIR:-/opt/tak/data/certs/files}"
+FED_DIR="${FED_DIR:-/opt/tak/data/federation}"
+FED_XML="${FED_DIR}/federation-extra.xml"
+
+FED_TLS_DIR="${FED_TLS_DIR:-/fed_certs}"     # cert-manager secret tak-federation-tls
+PEER_CA_DIR="${PEER_CA_DIR:-/fed_peer_ca}"   # ConfigMap of committed peer CA PEMs
+OWN_CA_DIR="${OWN_CA_DIR:-/ca_public}"       # written by the certs-handler init container
+
+# Names match firstrun_rm.sh. tak.externalsecret.yaml keeps these equal to the
+# TAKSERVER_CERT_PASS / CA_PASS that CoreConfig.tpl uses to open the same stores.
+TAKSERVER_KEYSTORE_PASS="${TAKSERVER_KEYSTORE_PASS:?TAKSERVER_KEYSTORE_PASS is required}"
+KEYSTORE_PASS="${KEYSTORE_PASS:?KEYSTORE_PASS is required}"
+
+FED_ALIAS="${TAK_SERVER_ADDRESS:-takserver}"
+FED_STRICT="${FED_STRICT:-true}"
+# Space-separated: <federateCA> takes unbounded inboundGroup/outboundGroup children,
+# so several groups can be mapped at once (e.g. "default __ANON__").
+FED_GROUP="${TAK_FEDERATION_GROUP:-default __ANON__}"
+# Asymmetric sharing: what we ACCEPT from a peer and what we SEND need not match.
+# Both default to TAK_FEDERATION_GROUP, so the symmetric case stays a single var.
+#   TAK_FEDERATION_GROUP_IN   - local groups incoming federated traffic is filed under
+#   TAK_FEDERATION_GROUP_OUT  - local groups whose traffic is shared with the peer
+# e.g. GROUP_OUT="recon" GROUP_IN="partner" exports only recon and quarantines
+# everything the peer sends into a group your own users are not in.
+FED_GROUP_IN="${TAK_FEDERATION_GROUP_IN:-${FED_GROUP}}"
+FED_GROUP_OUT="${TAK_FEDERATION_GROUP_OUT:-${FED_GROUP}}"
+FED_PEERS="${TAK_FEDERATION_PEERS:-}"
+FED_PORT="${TAK_FEDERATION_PORT:-9001}"
+FED_FETCH_RETRIES="${TAK_FEDERATION_FETCH_RETRIES:-5}"
+
+# TAK_SERVER_ADDRESS is tak.<host>; peers are listed as bare <host>.
+OWN_HOST="${FED_ALIAS#tak.}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+mkdir -p "${CERT_DIR}" "${FED_DIR}"
+
+log() { echo "federation-init: $*"; }
+fatal() {
+  log "FATAL - $*"
+  if [[ "${FED_STRICT}" == "true" ]]; then exit 1; fi
+  log "FED_STRICT=false, continuing with a federation identity that will not work"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Federation identity keystore
+#
+# Exactly ONE key entry: CoreConfig pins keymanager="SunX509", whose alias choice
+# is by key algorithm and issuer, so a second entry makes the choice ambiguous.
+#
+# The chain is mandatory, not cosmetic: TAK identifies a peer by its certArray[1]
+# (FederationServer.java). A leaf-only keystore throws ArrayIndexOutOfBounds inside
+# the interceptor, which surfaces only as a generic Status.INTERNAL.
+# ---------------------------------------------------------------------------
+if [[ ! -s "${FED_TLS_DIR}/tls.crt" || ! -s "${FED_TLS_DIR}/tls.key" ]]; then
+  # TAK_FED_KEYSTORE_FILE is set in base, so this path must always exist or every
+  # JVM fails to start. Falling back to takserver.jks keeps the pod behaving exactly
+  # as it did before federation existed: it comes up, and federation cannot
+  # authenticate outbound because the Let's Encrypt cert has no clientAuth EKU.
+  log "WARNING - no federation identity at ${FED_TLS_DIR}; falling back to takserver.jks"
+  log "WARNING - federation will NOT work until a tak-federation Certificate is deployed"
+  cp -v "${CERT_DIR}/takserver.jks" "${CERT_DIR}/fed-keystore.jks"
+else
+  # `openssl x509 -in` emits only the first certificate, so this strips any chain
+  # cert-manager already appended and -certfile below cannot duplicate it.
+  openssl x509 -in "${FED_TLS_DIR}/tls.crt" -out "${WORK}/leaf.pem"
+
+  EKU="$(openssl x509 -in "${WORK}/leaf.pem" -noout -ext extendedKeyUsage 2>/dev/null || true)"
+  log "identity subject : $(openssl x509 -in "${WORK}/leaf.pem" -noout -subject)"
+  log "identity issuer  : $(openssl x509 -in "${WORK}/leaf.pem" -noout -issuer)"
+  log "identity notAfter: $(openssl x509 -in "${WORK}/leaf.pem" -noout -enddate)"
+  log "identity EKU     : ${EKU//$'\n'/ }"
+
+  # Checked here because the peer, not us, is what rejects a clientAuth-less cert:
+  # SunX509 picks an alias by key type and issuer and never looks at the EKU, so
+  # we would present it happily and see only a TLS alert. The legible error lands
+  # in the PEER's log.
+  case "${EKU}" in *"TLS Web Client Authentication"*) ;; *)
+    fatal "federation identity has no clientAuth EKU; outgoing federation cannot authenticate" ;;
+  esac
+  case "${EKU}" in *"TLS Web Server Authentication"*) ;; *)
+    fatal "federation identity has no serverAuth EKU; inbound ${FED_PORT} cannot serve" ;;
+  esac
+
+  # Mirror firstrun_rm.sh's legacy-provider detection so both keystores are built
+  # by the same PKCS#12 code path.
+  LEGACY_PROVIDER=""
+  if ! openssl list -providers 2>&1 | grep -q "\(invalid command\|unknown option\)"; then
+    LEGACY_PROVIDER="-legacy"
+  fi
+
+  cat "${OWN_CA_DIR}/intermediate_ca.pem" "${OWN_CA_DIR}/root_ca.pem" > "${WORK}/chain.pem"
+
+  openssl pkcs12 ${LEGACY_PROVIDER} -export \
+    -out "${WORK}/fed.p12" \
+    -inkey "${FED_TLS_DIR}/tls.key" \
+    -in "${WORK}/leaf.pem" \
+    -certfile "${WORK}/chain.pem" \
+    -name "${FED_ALIAS}" \
+    -passout "pass:${TAKSERVER_KEYSTORE_PASS}"
+
+  rm -f "${CERT_DIR}/fed-keystore.jks"
+  keytool -importkeystore -noprompt \
+    -srcstoretype PKCS12 \
+    -srckeystore "${WORK}/fed.p12" -srcstorepass "${TAKSERVER_KEYSTORE_PASS}" \
+    -destkeystore "${CERT_DIR}/fed-keystore.jks" -deststoretype JKS \
+    -deststorepass "${TAKSERVER_KEYSTORE_PASS}" -destkeypass "${TAKSERVER_KEYSTORE_PASS}" \
+    -alias "${FED_ALIAS}"
+
+  CHAIN_LEN="$(keytool -list -v -keystore "${CERT_DIR}/fed-keystore.jks" \
+    -storepass "${TAKSERVER_KEYSTORE_PASS}" | sed -n 's/.*Certificate chain length: //p' | head -1)"
+  log "built fed-keystore.jks alias=${FED_ALIAS} chain length=${CHAIN_LEN:-0}"
+  if [[ "${CHAIN_LEN:-0}" -lt 2 ]]; then
+    fatal "fed-keystore.jks has no issuer in its chain; the peer cannot identify our CA"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Collect peer CAs
+#
+# Two sources, both optional and additive:
+#   - PEMs mounted from a ConfigMap  (manual / pinned peers)
+#   - fetched from TAK_FEDERATION_PEERS over HTTPS  (spawned fleets)
+# The fetch is NOT trust-on-first-use: /ca/public is served by Traefik on 443
+# behind a publicly trusted Let's Encrypt certificate, so curl verifies it.
+# ---------------------------------------------------------------------------
+mkdir -p "${WORK}/peers"
+shopt -s nullglob
+for pem in "${PEER_CA_DIR}"/*.pem; do
+  cp "${pem}" "${WORK}/peers/$(basename "${pem}")"
+  log "peer CA from configmap: $(basename "${pem}")"
+done
+shopt -u nullglob
+
+for peer in ${FED_PEERS}; do
+  if [[ "${peer}" == "${OWN_HOST}" ]]; then
+    continue
+  fi
+  if curl -fsS --retry "${FED_FETCH_RETRIES}" --retry-delay 5 --retry-connrefused --max-time 30 \
+       "https://${peer}/ca/public/intermediate_ca.pem" -o "${WORK}/peers/${peer}.pem"; then
+    log "peer CA fetched: ${peer}"
+  else
+    # Never fail the pod for an unreachable peer: when a fleet is spawned in
+    # parallel some peers do not exist yet. A missing peer means no <federateCA>
+    # for it, so the link is simply absent rather than half-configured. Re-run
+    # (kubectl rollout restart) once the whole fleet is up.
+    rm -f "${WORK}/peers/${peer}.pem"
+    log "WARNING - could not fetch CA for ${peer}; it will not be federated this run"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. Federation truststore
+#
+# Rebuilt from scratch so it is a pure function of the inputs above.
+# truststore-root.jks is deliberately NOT touched: it authenticates ATAK clients
+# on 8089, and a peer unit's CA in there would let that unit mint users here.
+# firstrun_rm.sh leaves both files as our own CAs, so adding peers to this one
+# alone is what splits them.
+# ---------------------------------------------------------------------------
+import_ca() { # import_ca <alias> <pem>
+  local alias="$1" pem="$2"
+  keytool -noprompt -importcert -trustcacerts \
+    -alias "${alias}" -file "${pem}" \
+    -keystore "${CERT_DIR}/fed-truststore.jks" -storepass "${KEYSTORE_PASS}"
+}
+
+ca_fingerprint() { openssl x509 -in "$1" -noout -fingerprint -sha256 | cut -d= -f2; }
+
+rm -f "${CERT_DIR}/fed-truststore.jks"
+import_ca RM_Root "${OWN_CA_DIR}/root_ca.pem"
+import_ca RM_Intermediate "${OWN_CA_DIR}/intermediate_ca.pem"
+
+OUTGOING=""
+FEDERATE_CA=""
+PEER_COUNT=0
+
+shopt -s nullglob
+for pem in "${WORK}/peers"/*.pem; do
+  grep -q "BEGIN CERTIFICATE" "${pem}" || { log "WARNING - ${pem} is not a certificate"; continue; }
+  peer="$(basename "${pem}" .pem)"
+  import_ca "peer_${peer}" "${pem}"
+  fp="$(ca_fingerprint "${pem}")"
+  PEER_COUNT=$((PEER_COUNT + 1))
+  log "trust peer_${peer}  sha256=${fp}  $(openssl x509 -in "${pem}" -noout -subject)"
+
+  groups=""
+  for g in ${FED_GROUP_IN}; do
+    groups="${groups}            <inboundGroup>${g}</inboundGroup>
+"
+  done
+  for g in ${FED_GROUP_OUT}; do
+    groups="${groups}            <outboundGroup>${g}</outboundGroup>
+"
+  done
+  FEDERATE_CA="${FEDERATE_CA}        <federateCA fingerprint=\"${fp}\" maxHops=\"-1\" allowTokenAuth=\"false\">
+${groups}        </federateCA>
+"
+  # Exactly one side of each pair must dial: FederationServer raises
+  # DuplicateFederateException and the link flaps if both do. Comparing hostnames
+  # gives a stable answer on both sides with no coordination.
+  if [[ "${peer}" > "${OWN_HOST}" ]]; then
+    OUTGOING="${OUTGOING}        <federation-outgoing displayName=\"${peer}\" address=\"tak.${peer}\" port=\"${FED_PORT}\" protocolVersion=\"2\" enabled=\"true\" tls=\"true\" reconnectInterval=\"30\" unlimitedRetries=\"true\" maxFrameSize=\"268435456\"/>
+"
+    log "will dial tak.${peer}:${FED_PORT} (we sort first)"
+  else
+    log "will wait for tak.${peer} to dial us (they sort first)"
+  fi
+done
+shopt -u nullglob
+
+keytool -list -keystore "${CERT_DIR}/fed-truststore.jks" -storepass "${KEYSTORE_PASS}" \
+  | sed 's/^/federation-init: /'
+
+# ---------------------------------------------------------------------------
+# 4. The generated <federation> tail
+#
+# Child order is fixed by CoreConfig.xsd: federation-outgoing*, fileFilter, federateCA*.
+# No peers -> no file -> CoreConfig.tpl falls back to the stock <fileFilter> block.
+# ---------------------------------------------------------------------------
+if [[ "${PEER_COUNT}" -eq 0 ]]; then
+  rm -f "${FED_XML}"
+  log "no peers configured; CoreConfig will use the stock federation block"
+else
+  printf '%s        <fileFilter>\n            <fileExtension>pref</fileExtension>\n        </fileFilter>\n%s' \
+    "${OUTGOING}" "${FEDERATE_CA}" > "${FED_XML}"
+  log "wrote ${FED_XML} for ${PEER_COUNT} peer(s), in=${FED_GROUP_IN} out=${FED_GROUP_OUT}"
+  case " ${FED_GROUP_OUT} " in *" default "*) ;; *)
+    # Deploy App enrols users with a bare `UserManager certmod` (enable_user.sh, no -g),
+    # which puts them in __ANON__ - verified in UserAuthenticationFile.xml on a live
+    # deployment. x509addAnonymous="false" only stops the *automatic* x509 add; the
+    # explicit groupList still applies. So __ANON__ is the group that actually has
+    # members here, and anything else needs its membership arranged first.
+    # Measured on a live deployment: a cert-authenticated client's runtime subscription
+    # lands in "default", even though UserAuthenticationFile.xml lists __ANON__ for the
+    # same user. Federation only forwards where the client's groups and the federate's
+    # groups intersect, so leaving "default" out silently forwards nothing.
+    log "NOTE - outbound group list ${FED_GROUP_OUT} does not include \"default\"."
+    log "NOTE - Connected clients are usually in \"default\" at runtime; without it,"
+    log "NOTE - federation connects cleanly and sends no CoT at all." ;;
+  esac
+fi
+
+log "done"

--- a/scripts/federation-init.sh
+++ b/scripts/federation-init.sh
@@ -88,7 +88,18 @@ if [[ ! -s "${FED_TLS_DIR}/tls.crt" || ! -s "${FED_TLS_DIR}/tls.key" ]]; then
   # as it did before federation existed: it comes up, and federation cannot
   # authenticate outbound because the Let's Encrypt cert has no clientAuth EKU.
   log "WARNING - no federation identity at ${FED_TLS_DIR}; falling back to takserver.jks"
-  log "WARNING - federation will NOT work until a tak-federation Certificate is deployed"
+  log "WARNING - federation will NOT work: takserver.jks holds the web certificate, and a"
+  log "WARNING - Let's Encrypt cert has no clientAuth EKU, so no peer can ever accept it."
+  if [[ "${TAK_FEDERATION_ENABLED:-false}" == "true" ]]; then
+    # The operator asked for an identity and did not get one, so the mint is broken
+    # rather than merely skipped. Say so, because the fallback below looks identical.
+    log "WARNING - TAK_FEDERATION_ENABLED=true but no identity arrived: the mint did not"
+    log "WARNING - run or it failed. Check the takfedinit cfssl step and the cfssl logs."
+  else
+    log "WARNING - To fix on compose: set TAK_FEDERATION_ENABLED=true (or configure"
+    log "WARNING - TAK_FEDERATION_PEERS) and restart. On Kubernetes: deploy the"
+    log "WARNING - tak-federation Certificate so ${FED_TLS_DIR} is populated."
+  fi
   cp -v "${CERT_DIR}/takserver.jks" "${CERT_DIR}/fed-keystore.jks"
 else
   # Everything that can fail on a bad identity lives in this function, and it is

--- a/scripts/federation-init.sh
+++ b/scripts/federation-init.sh
@@ -17,6 +17,9 @@ set -euo pipefail
 CERT_DIR="${CERT_DIR:-/opt/tak/data/certs/files}"
 FED_DIR="${FED_DIR:-/opt/tak/data/federation}"
 FED_XML="${FED_DIR}/federation-extra.xml"
+# First-seen peer CA fingerprints. On the tak-data volume so it survives restarts:
+# without it the "pin" would be re-derived from the network on every boot.
+KNOWN_DIR="${FED_DIR}/known-peer-cas"
 
 FED_TLS_DIR="${FED_TLS_DIR:-/fed_certs}"     # cert-manager secret tak-federation-tls
 PEER_CA_DIR="${PEER_CA_DIR:-/fed_peer_ca}"   # ConfigMap of committed peer CA PEMs
@@ -28,7 +31,12 @@ TAKSERVER_KEYSTORE_PASS="${TAKSERVER_KEYSTORE_PASS:?TAKSERVER_KEYSTORE_PASS is r
 KEYSTORE_PASS="${KEYSTORE_PASS:?KEYSTORE_PASS is required}"
 
 FED_ALIAS="${TAK_SERVER_ADDRESS:-takserver}"
-FED_STRICT="${FED_STRICT:-true}"
+# Default false: federation is an OPTIONAL feature and must not be able to take
+# port 8089 down for every fielded ATAK client. A broken federation identity now
+# degrades to "federation off" and TAK starts normally. Set true in CI, where a
+# hard failure is exactly what you want.
+FED_STRICT="${FED_STRICT:-false}"
+FED_DEGRADED=0
 # Space-separated: <federateCA> takes unbounded inboundGroup/outboundGroup children,
 # so several groups can be mapped at once (e.g. "default __ANON__").
 FED_GROUP="${TAK_FEDERATION_GROUP:-default __ANON__}"
@@ -53,9 +61,15 @@ mkdir -p "${CERT_DIR}" "${FED_DIR}"
 
 log() { echo "federation-init: $*"; }
 fatal() {
-  log "FATAL - $*"
-  if [[ "${FED_STRICT}" == "true" ]]; then exit 1; fi
-  log "FED_STRICT=false, continuing with a federation identity that will not work"
+  log "ERROR - $*"
+  if [[ "${FED_STRICT}" == "true" ]]; then
+    log "FED_STRICT=true, failing the container"
+    exit 1
+  fi
+  # Do NOT carry on building federation config from a broken identity: that used to
+  # produce a half-configured server. Mark it and bail out cleanly below instead.
+  log "Federation DISABLED for this run; TAK itself will start normally."
+  FED_DEGRADED=1
 }
 
 # ---------------------------------------------------------------------------
@@ -77,9 +91,15 @@ if [[ ! -s "${FED_TLS_DIR}/tls.crt" || ! -s "${FED_TLS_DIR}/tls.key" ]]; then
   log "WARNING - federation will NOT work until a tak-federation Certificate is deployed"
   cp -v "${CERT_DIR}/takserver.jks" "${CERT_DIR}/fed-keystore.jks"
 else
+  # Everything that can fail on a bad identity lives in this function, and it is
+  # called with `if ! ...` so `set -e` is suspended for the whole call. Without
+  # that, a corrupt tls.crt aborts the script outright and never reaches fatal(),
+  # which is exactly how a broken federation cert used to take TAK down.
+  build_fed_identity() {
   # `openssl x509 -in` emits only the first certificate, so this strips any chain
   # cert-manager already appended and -certfile below cannot duplicate it.
-  openssl x509 -in "${FED_TLS_DIR}/tls.crt" -out "${WORK}/leaf.pem"
+  openssl x509 -in "${FED_TLS_DIR}/tls.crt" -out "${WORK}/leaf.pem" 2>/dev/null \
+    || { log "ERROR - ${FED_TLS_DIR}/tls.crt is not a readable certificate"; return 1; }
 
   EKU="$(openssl x509 -in "${WORK}/leaf.pem" -noout -ext extendedKeyUsage 2>/dev/null || true)"
   log "identity subject : $(openssl x509 -in "${WORK}/leaf.pem" -noout -subject)"
@@ -92,10 +112,12 @@ else
   # we would present it happily and see only a TLS alert. The legible error lands
   # in the PEER's log.
   case "${EKU}" in *"TLS Web Client Authentication"*) ;; *)
-    fatal "federation identity has no clientAuth EKU; outgoing federation cannot authenticate" ;;
+    log "ERROR - federation identity has no clientAuth EKU; outgoing federation cannot authenticate"
+    return 1 ;;
   esac
   case "${EKU}" in *"TLS Web Server Authentication"*) ;; *)
-    fatal "federation identity has no serverAuth EKU; inbound ${FED_PORT} cannot serve" ;;
+    log "ERROR - federation identity has no serverAuth EKU; inbound ${FED_PORT} cannot serve"
+    return 1 ;;
   esac
 
   # Mirror firstrun_rm.sh's legacy-provider detection so both keystores are built
@@ -127,29 +149,66 @@ else
     -storepass "${TAKSERVER_KEYSTORE_PASS}" | sed -n 's/.*Certificate chain length: //p' | head -1)"
   log "built fed-keystore.jks alias=${FED_ALIAS} chain length=${CHAIN_LEN:-0}"
   if [[ "${CHAIN_LEN:-0}" -lt 2 ]]; then
-    fatal "fed-keystore.jks has no issuer in its chain; the peer cannot identify our CA"
+    log "ERROR - fed-keystore.jks has no issuer in its chain; the peer cannot identify our CA"
+    return 1
   fi
+  return 0
+  }
+
+  if ! build_fed_identity; then
+    fatal "could not build a usable federation identity from ${FED_TLS_DIR}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 1b. Degrade cleanly if the identity is unusable
+#
+# CoreConfig points TAK_FED_KEYSTORE_FILE at fed-keystore.jks unconditionally, so
+# that file must exist or every JVM fails to start. Leave a working keystore, drop
+# any stale fragment, and exit 0 so the rest of TAK comes up without federation.
+# ---------------------------------------------------------------------------
+if [[ "${FED_DEGRADED}" == "1" ]]; then
+  if [[ ! -s "${CERT_DIR}/fed-keystore.jks" ]]; then
+    cp -v "${CERT_DIR}/takserver.jks" "${CERT_DIR}/fed-keystore.jks"
+  fi
+  rm -f "${FED_XML}"
+  log "done (federation disabled, TAK unaffected)"
+  exit 0
 fi
 
 # ---------------------------------------------------------------------------
 # 2. Collect peer CAs
 #
-# Two sources, both optional and additive:
-#   - PEMs mounted from a ConfigMap  (manual / pinned peers)
-#   - fetched from TAK_FEDERATION_PEERS over HTTPS  (spawned fleets)
-# The fetch is NOT trust-on-first-use: /ca/public is served by Traefik on 443
-# behind a publicly trusted Let's Encrypt certificate, so curl verifies it.
+# Two sources, in strict precedence order:
+#   1. PEMs mounted from a ConfigMap  -- AUTHORITATIVE, never fetched over
+#   2. fetched from TAK_FEDERATION_PEERS over HTTPS  (spawned fleets)
+#
+# What the fetch actually proves is only "somebody who can pass ACME for that
+# hostname", so it is trust-on-first-use, not a pin. curl does verify TLS (there
+# is deliberately no -k and no -L, so a redirect-to-http downgrade is blocked),
+# but DNS control over a peer name is enough to serve us a hostile CA. That is
+# why the first-seen fingerprint is remembered in KNOWN_DIR below and a change
+# is refused: mount the CA from a ConfigMap to pin it from the very first run.
 # ---------------------------------------------------------------------------
-mkdir -p "${WORK}/peers"
+mkdir -p "${WORK}/peers" "${KNOWN_DIR}"
+PINNED_PEERS=""
 shopt -s nullglob
 for pem in "${PEER_CA_DIR}"/*.pem; do
   cp "${pem}" "${WORK}/peers/$(basename "${pem}")"
-  log "peer CA from configmap: $(basename "${pem}")"
+  PINNED_PEERS="${PINNED_PEERS} $(basename "${pem}" .pem)"
+  log "peer CA from configmap (authoritative): $(basename "${pem}")"
 done
 shopt -u nullglob
 
 for peer in ${FED_PEERS}; do
   if [[ "${peer}" == "${OWN_HOST}" ]]; then
+    continue
+  fi
+  # A ConfigMap-mounted CA is the operator's explicit pin. Fetching over it would
+  # let whoever controls the peer's DNS silently replace it -- and the rm -f below
+  # would delete it outright when the fetch failed.
+  if [[ " ${PINNED_PEERS} " == *" ${peer} "* ]]; then
+    log "peer CA for ${peer} is pinned by configmap; not fetching"
     continue
   fi
   if curl -fsS --retry "${FED_FETCH_RETRIES}" --retry-delay 5 --retry-connrefused --max-time 30 \
@@ -195,8 +254,28 @@ shopt -s nullglob
 for pem in "${WORK}/peers"/*.pem; do
   grep -q "BEGIN CERTIFICATE" "${pem}" || { log "WARNING - ${pem} is not a certificate"; continue; }
   peer="$(basename "${pem}" .pem)"
-  import_ca "peer_${peer}" "${pem}"
   fp="$(ca_fingerprint "${pem}")"
+
+  # Fingerprint must be checked BEFORE the CA is imported, or a rotated hostile CA
+  # is already a trust anchor by the time we notice. Pinned CAs skip this: the
+  # ConfigMap is the pin, and an operator editing it should win.
+  if [[ " ${PINNED_PEERS} " != *" ${peer} "* ]]; then
+    known="${KNOWN_DIR}/${peer}.sha256"
+    if [[ -f "${known}" && "$(cat "${known}")" != "${fp}" ]]; then
+      log "REFUSING ${peer}: CA fingerprint changed since first trust"
+      log "  expected $(cat "${known}")"
+      log "  got      ${fp}"
+      log "  Someone who controls that hostname can serve any CA. If this rotation"
+      log "  is legitimate: rm ${known} and restart. Not federating with it now."
+      continue
+    fi
+    if [[ ! -f "${known}" ]]; then
+      echo "${fp}" > "${known}"
+      log "recorded first-seen CA for ${peer} (pin it via configmap to avoid TOFU)"
+    fi
+  fi
+
+  import_ca "peer_${peer}" "${pem}"
   PEER_COUNT=$((PEER_COUNT + 1))
   log "trust peer_${peer}  sha256=${fp}  $(openssl x509 -in "${pem}" -noout -subject)"
 

--- a/scripts/firstrun_rm.sh
+++ b/scripts/firstrun_rm.sh
@@ -103,10 +103,21 @@ if [[ -f "/ca_public/miniwerk_ca.pem" ]];then
     -storepass ${KEYSTORE_PASS}
 fi
 
-# fed-truststore.jks is needed, copy takserver-truststore.jks
-# TODO what are the names of truststores that we actually need???
-cp -v /opt/tak/data/certs/files/takserver-truststore.jks /opt/tak/data/certs/files/fed-truststore.jks
+# truststore-root.jks authenticates ATAK *clients* on 8089/8443, so it stays exactly our
+# own CAs and nothing else. A federation peer's CA must never end up in here: it would let
+# that peer's unit mint users on this server.
 cp -v /opt/tak/data/certs/files/takserver-truststore.jks /opt/tak/data/certs/files/truststore-root.jks
+
+# fed-truststore.jks authenticates federation *peers* and therefore has to be able to hold
+# CAs that truststore-root.jks must not. This block runs above the firstrun.done early-exit
+# below, i.e. on every container start, so an unconditional copy here silently discards every
+# peer CA on restart and federation comes back up trusting nobody. Seed it only when it does
+# not exist yet, and leave it alone afterwards for whatever manages peer trust to own.
+if [[ ! -f /opt/tak/data/certs/files/fed-truststore.jks ]];then
+  cp -v /opt/tak/data/certs/files/takserver-truststore.jks /opt/tak/data/certs/files/fed-truststore.jks
+else
+  echo "Keeping existing fed-truststore.jks"
+fi
 
 popd >> /dev/null
 

--- a/templates/CoreConfig.tpl
+++ b/templates/CoreConfig.tpl
@@ -77,15 +77,34 @@
 
     <federation allowFederatedDelete="false" allowMissionFederation="true" allowDataFeedFederation="true" enableMissionFederationDisruptionTolerance="true" missionFederationDisruptionToleranceRecencySeconds="43200" enableFederation="true" enableDataPackageAndMissionFileFilter="false">
         <federation-server port="9000" coreVersion="2" v1enabled="false" v2port="9001" v2enabled="true" webBaseUrl="https://{{.Env.TAK_SERVER_ADDRESS}}:8443/Marti">
-            <tls keystore="JKS" keystoreFile="certs/files/takserver.jks" keystorePass="{{.Env.TAKSERVER_CERT_PASS}}" truststore="JKS" truststoreFile="certs/files/fed-truststore.jks" truststorePass="{{.Env.CA_PASS}}" context="TLSv1.2" keymanager="SunX509"/>
+            <!-- Federation v2 is mutual TLS, so this keystore is our identity as a TLS
+                 *client* when we dial a peer, not only as a server. Let's Encrypt stopped
+                 issuing the clientAuth EKU during 2026, so an LE-based takserver.jks can no
+                 longer authenticate outbound federation at all. Point TAK_FED_KEYSTORE_FILE
+                 at a keystore built from a deployment-CA identity to federate; the default
+                 keeps today's behaviour. The keystore must contain the issuing chain, not
+                 just the leaf: FederationServer identifies a peer by its certArray[1]. -->
+            <tls keystore="JKS" keystoreFile="{{getenv "TAK_FED_KEYSTORE_FILE" "certs/files/takserver.jks"}}" keystorePass="{{.Env.TAKSERVER_CERT_PASS}}" truststore="JKS" truststoreFile="certs/files/fed-truststore.jks" truststorePass="{{.Env.CA_PASS}}" context="TLSv1.2" keymanager="SunX509"/>
             <federation-port port="9000" tlsVersion="TLSv1.2"/>
             <v1Tls tlsVersion="TLSv1.2"/>
             <v1Tls tlsVersion="TLSv1.3"/>
             <federation-token-authentication enabled="true" tls="true" port="9002"/>
         </federation-server>
+        <!-- Everything between </federation-server> and </federation> can be supplied as a
+             generated fragment. CoreConfig.xsd fixes the child order here as
+             federation-outgoing*, fileFilter, federateCA* - fileFilter is required and sits
+             between the two things an operator needs to add, so the fragment owns the whole
+             tail rather than being spliced in two places.
+             This is the only durable place for federation config: start-tak.sh regenerates
+             CoreConfig.xml from this template on every container start, so <federate> entries
+             written by the admin UI or by auto-discovery are lost on restart. -->
+{{if file.Exists (getenv "TAK_FEDERATION_EXTRA_FILE" "/opt/tak/data/federation/federation-extra.xml")}}
+{{- file.Read (getenv "TAK_FEDERATION_EXTRA_FILE" "/opt/tak/data/federation/federation-extra.xml")}}
+{{- else}}
         <fileFilter>
             <fileExtension>pref</fileExtension>
         </fileFilter>
+{{- end}}
     </federation>
 
     <logging

--- a/templates/CoreConfig.tpl
+++ b/templates/CoreConfig.tpl
@@ -88,7 +88,12 @@
             <federation-port port="9000" tlsVersion="TLSv1.2"/>
             <v1Tls tlsVersion="TLSv1.2"/>
             <v1Tls tlsVersion="TLSv1.3"/>
-            <federation-token-authentication enabled="true" tls="true" port="9002"/>
+            <!-- Off by default, matching the XSD default. This is a second front door:
+                 a federate authenticating with a bearer token bypasses fed-truststore.jks
+                 and the <federateCA> fingerprint list entirely. Nothing here uses it -
+                 federation-outgoing is generated without useToken - so leave it shut and
+                 do not publish 9002. -->
+            <federation-token-authentication enabled="{{getenv "TAK_FEDERATION_TOKEN_AUTH" "false"}}" tls="true" port="9002"/>
         </federation-server>
         <!-- Everything between </federation-server> and </federation> can be supplied as a
              generated fragment. CoreConfig.xsd fixes the child order here as

--- a/tests/federation/test-federation-init.sh
+++ b/tests/federation/test-federation-init.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Runs k8s/app-tak/base/scripts/federation-init.sh against stubbed openssl/keytool/curl
+# and checks the two things that are silently wrong if they break:
+#   - <federation> child order (CoreConfig.xsd: federation-outgoing*, fileFilter, federateCA*)
+#   - exactly one side of each pair dials, decided by hostname comparison
+#
+# No cluster, no network, no dependencies beyond bash and xmllint.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="${REPO}/scripts/federation-init.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+mkdir -p "${TMP}/bin" "${TMP}/ca_public" "${TMP}/fed_certs" "${TMP}/fed_peer_ca" \
+         "${TMP}/opt/tak/data/certs/files"
+
+for f in root_ca intermediate_ca; do
+  printf -- '-----BEGIN CERTIFICATE-----\n%s\n-----END CERTIFICATE-----\n' "${f}" \
+    > "${TMP}/ca_public/${f}.pem"
+done
+cp "${TMP}/ca_public/root_ca.pem" "${TMP}/fed_certs/tls.crt"
+printf 'key\n' > "${TMP}/fed_certs/tls.key"
+cp "${TMP}/ca_public/root_ca.pem" "${TMP}/fed_peer_ca/pinned-peer.solution.example.pem"
+
+cat > "${TMP}/bin/openssl" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  list) echo "providers"; exit 0 ;;
+  pkcs12) for a in "$@"; do [ "$prev" = "-out" ] && : > "$a"; prev="$a"; done; exit 0 ;;
+  x509)
+    out=""; prev=""
+    for a in "$@"; do [ "$prev" = "-out" ] && out="$a"; prev="$a"; done
+    if [ -n "$out" ]; then printf -- '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n' > "$out"; exit 0; fi
+    case " $* " in
+      *" extendedKeyUsage"*) echo "X509v3 Extended Key Usage:"; echo "    TLS Web Server Authentication, TLS Web Client Authentication" ;;
+      *" -fingerprint "*) echo "sha256 Fingerprint=AA:BB:CC:DD" ;;
+      *" -subject"*) echo "subject=CN=stub" ;;
+      *" -issuer"*) echo "issuer=CN=stub-ca" ;;
+      *" -enddate"*) echo "notAfter=Jan 1 00:00:00 2030 GMT" ;;
+    esac
+    exit 0 ;;
+esac
+exit 0
+STUB
+
+cat > "${TMP}/bin/keytool" <<'STUB'
+#!/usr/bin/env bash
+case " $* " in
+  *" -importkeystore "*) for a in "$@"; do [ "$prev" = "-destkeystore" ] && : > "$a"; prev="$a"; done ;;
+  *" -list "*) case " $* " in *" -v "*) echo "Certificate chain length: 3" ;; *) echo "stub truststore" ;; esac ;;
+esac
+exit 0
+STUB
+
+# Fetch succeeds except for the host named "unreachable", which covers the
+# spawn-ordering path where a peer does not exist yet.
+cat > "${TMP}/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+out=""; url=""; prev=""
+for a in "$@"; do
+  [ "$prev" = "-o" ] && out="$a"
+  case "$a" in https://*) url="$a" ;; esac
+  prev="$a"
+done
+case "$url" in *unreachable*) exit 22 ;; esac
+printf -- '-----BEGIN CERTIFICATE-----\nfetched\n-----END CERTIFICATE-----\n' > "$out"
+STUB
+chmod +x "${TMP}/bin"/*
+
+PATH="${TMP}/bin:${PATH}" \
+CERT_DIR_OVERRIDE=1 \
+OWN_CA_DIR="${TMP}/ca_public" \
+FED_TLS_DIR="${TMP}/fed_certs" \
+PEER_CA_DIR="${TMP}/fed_peer_ca" \
+TAKSERVER_KEYSTORE_PASS=x \
+KEYSTORE_PASS=y \
+TAK_SERVER_ADDRESS="tak.mmm.solution.example" \
+TAK_FEDERATION_GROUP="default __ANON__" \
+TAK_FEDERATION_PEERS="aaa.solution.example mmm.solution.example zzz.solution.example unreachable.solution.example" \
+TAK_FEDERATION_FETCH_RETRIES=0 \
+CERT_DIR="${TMP}/opt/tak/data/certs/files" \
+FED_DIR="${TMP}/opt/tak/data/federation" \
+  bash "${SCRIPT_UNDER_TEST}" \
+  > "${TMP}/out.log" 2>&1 || { echo "FAIL: script exited non-zero"; cat "${TMP}/out.log"; exit 1; }
+
+XML="${TMP}/opt/tak/data/federation/federation-extra.xml"
+[ -s "${XML}" ] || { echo "FAIL: no federation-extra.xml written"; cat "${TMP}/out.log"; exit 1; }
+
+# 1. Well-formed once wrapped in its parent element.
+{ echo "<federation>"; cat "${XML}"; echo "</federation>"; } > "${TMP}/frag.xml"
+xmllint --noout "${TMP}/frag.xml" || { echo "FAIL: generated XML is not well-formed"; exit 1; }
+
+# 2. Child order: federation-outgoing before fileFilter before federateCA.
+order="$(grep -oE '<(federation-outgoing|fileFilter|federateCA)' "${XML}" | sed 's/<//' | uniq | tr '\n' ' ')"
+[ "${order}" = "federation-outgoing fileFilter federateCA " ] \
+  || { echo "FAIL: wrong child order: '${order}'"; cat "${XML}"; exit 1; }
+
+# 3. The pinned peer got a federateCA entry even though every fetch failed.
+grep -q 'federateCA fingerprint="AA:BB:CC:DD"' "${XML}" \
+  || { echo "FAIL: pinned peer CA produced no federateCA"; exit 1; }
+
+# 4. Dial direction: we are mmm, so we dial zzz and never aaa or ourselves.
+grep -q 'address="tak.zzz.solution.example"' "${XML}" \
+  || { echo "FAIL: expected an outgoing connection to zzz"; cat "${XML}"; exit 1; }
+grep -q 'address="tak.aaa.solution.example"' "${XML}" \
+  && { echo "FAIL: must not dial aaa, it sorts before us"; cat "${XML}"; exit 1; }
+grep -q 'tak.mmm.solution.example"' "${XML}" \
+  && { echo "FAIL: must not federate with ourselves"; exit 1; }
+
+# 5. aaa is trusted (federateCA) but not dialled - it sorts before us and dials in.
+grep -q 'will wait for tak.aaa.solution.example' "${TMP}/out.log" \
+  || { echo "FAIL: expected to wait for aaa to dial us"; cat "${TMP}/out.log"; exit 1; }
+
+# 6. An unreachable peer warns and is skipped, and does not fail the pod.
+grep -q 'could not fetch CA for unreachable.solution.example' "${TMP}/out.log" \
+  || { echo "FAIL: expected a warning for the unreachable peer"; exit 1; }
+grep -q 'unreachable.solution.example' "${XML}" \
+  && { echo "FAIL: unreachable peer must not appear in the generated XML"; exit 1; }
+
+# 7. A group list produces one inbound/outbound pair per group.
+[ "$(grep -c '<inboundGroup>' "${XML}")" = "6" ] \
+  || { echo "FAIL: expected 2 groups x 3 peers of inboundGroup"; cat "${XML}"; exit 1; }
+grep -q '<inboundGroup>__ANON__</inboundGroup>' "${XML}" \
+  || { echo "FAIL: second group missing"; exit 1; }
+
+# 8. Asymmetric sharing: IN and OUT lists are applied independently.
+PATH="${TMP}/bin:${PATH}" \
+CERT_DIR_OVERRIDE=1 \
+OWN_CA_DIR="${TMP}/ca_public" \
+FED_TLS_DIR="${TMP}/fed_certs" \
+PEER_CA_DIR="${TMP}/fed_peer_ca" \
+TAKSERVER_KEYSTORE_PASS=x \
+KEYSTORE_PASS=y \
+TAK_SERVER_ADDRESS="tak.mmm.solution.example" \
+TAK_FEDERATION_GROUP_IN="partner" \
+TAK_FEDERATION_GROUP_OUT="default recon" \
+TAK_FEDERATION_PEERS="aaa.solution.example mmm.solution.example zzz.solution.example" \
+TAK_FEDERATION_FETCH_RETRIES=0 \
+CERT_DIR="${TMP}/opt/tak/data/certs/files" \
+FED_DIR="${TMP}/opt/tak/data/federation2" \
+  bash "${SCRIPT_UNDER_TEST}" \
+  > "${TMP}/out2.log" 2>&1 || { echo "FAIL: asymmetric run exited non-zero"; cat "${TMP}/out2.log"; exit 1; }
+
+XML2="${TMP}/opt/tak/data/federation2/federation-extra.xml"
+# 3 trusted peer CAs x 1 inbound group, x 2 outbound groups.
+[ "$(grep -c '<inboundGroup>partner</inboundGroup>' "${XML2}")" = "3" ] \
+  || { echo "FAIL: expected 3 inboundGroup partner"; cat "${XML2}"; exit 1; }
+[ "$(grep -c '<outboundGroup>' "${XML2}")" = "6" ] \
+  || { echo "FAIL: expected 6 outboundGroup"; cat "${XML2}"; exit 1; }
+grep -q '<outboundGroup>partner</outboundGroup>' "${XML2}" \
+  && { echo "FAIL: inbound-only group leaked into outbound"; exit 1; }
+grep -q '<inboundGroup>recon</inboundGroup>' "${XML2}" \
+  && { echo "FAIL: outbound-only group leaked into inbound"; exit 1; }
+{ echo "<federation>"; cat "${XML2}"; echo "</federation>"; } > "${TMP}/frag2.xml"
+xmllint --noout "${TMP}/frag2.xml" || { echo "FAIL: asymmetric XML not well-formed"; exit 1; }
+
+echo "PASS: order, pinned peer, dial direction, group list, asymmetric in/out, self-exclusion, unreachable-peer tolerance"

--- a/tests/federation/test-federation-init.sh
+++ b/tests/federation/test-federation-init.sh
@@ -33,10 +33,13 @@ case "$1" in
   x509)
     out=""; prev=""
     for a in "$@"; do [ "$prev" = "-out" ] && out="$a"; prev="$a"; done
-    if [ -n "$out" ]; then printf -- '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n' > "$out"; exit 0; fi
+    if [ -n "$out" ]; then
+      if [ -n "${STUB_BAD_CERT:-}" ]; then echo "Unable to load certificate" >&2; exit 1; fi
+      printf -- '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n' > "$out"; exit 0
+    fi
     case " $* " in
-      *" extendedKeyUsage"*) echo "X509v3 Extended Key Usage:"; echo "    TLS Web Server Authentication, TLS Web Client Authentication" ;;
-      *" -fingerprint "*) echo "sha256 Fingerprint=AA:BB:CC:DD" ;;
+      *" extendedKeyUsage"*) echo "X509v3 Extended Key Usage:"; echo "    ${STUB_EKU:-TLS Web Server Authentication, TLS Web Client Authentication}" ;;
+      *" -fingerprint "*) echo "sha256 Fingerprint=${STUB_FP:-AA:BB:CC:DD}" ;;
       *" -subject"*) echo "subject=CN=stub" ;;
       *" -issuer"*) echo "issuer=CN=stub-ca" ;;
       *" -enddate"*) echo "notAfter=Jan 1 00:00:00 2030 GMT" ;;
@@ -157,4 +160,79 @@ grep -q '<inboundGroup>recon</inboundGroup>' "${XML2}" \
 { echo "<federation>"; cat "${XML2}"; echo "</federation>"; } > "${TMP}/frag2.xml"
 xmllint --noout "${TMP}/frag2.xml" || { echo "FAIL: asymmetric XML not well-formed"; exit 1; }
 
-echo "PASS: order, pinned peer, dial direction, group list, asymmetric in/out, self-exclusion, unreachable-peer tolerance"
+# ---------------------------------------------------------------------------
+# Security fixes: findings 1 and 7
+# ---------------------------------------------------------------------------
+run_fed() {  # run_fed <feddir> [extra env assignments...]
+  local feddir="$1"; shift
+  env PATH="${TMP}/bin:${PATH}" \
+      OWN_CA_DIR="${TMP}/ca_public" \
+      FED_TLS_DIR="${TMP}/fed_certs" \
+      PEER_CA_DIR="${TMP}/fed_peer_ca" \
+      TAKSERVER_KEYSTORE_PASS=x KEYSTORE_PASS=y \
+      TAK_SERVER_ADDRESS="tak.mmm.solution.example" \
+      TAK_FEDERATION_PEERS="zzz.solution.example pinned-peer.solution.example" \
+      TAK_FEDERATION_FETCH_RETRIES=0 \
+      CERT_DIR="${TMP}/opt/tak/data/certs/files" \
+      FED_DIR="${feddir}" \
+      "$@" bash "${SCRIPT_UNDER_TEST}"
+}
+
+# 9. Finding 1b: a changed peer CA fingerprint is REFUSED, not silently re-trusted.
+D9="${TMP}/opt/tak/data/fed9"
+run_fed "$D9" > "${TMP}/r9a.log" 2>&1 || { echo "FAIL: first run failed"; cat "${TMP}/r9a.log"; exit 1; }
+grep -q 'recorded first-seen CA for zzz.solution.example' "${TMP}/r9a.log" \
+  || { echo "FAIL: first-seen fingerprint not recorded"; cat "${TMP}/r9a.log"; exit 1; }
+[ -f "$D9/known-peer-cas/zzz.solution.example.sha256" ] \
+  || { echo "FAIL: no persisted fingerprint file"; exit 1; }
+grep -q '<federateCA fingerprint="AA:BB:CC:DD"' "$D9/federation-extra.xml" \
+  || { echo "FAIL: peer not federated on first run"; exit 1; }
+
+run_fed "$D9" STUB_FP="EE:FF:00:11" > "${TMP}/r9b.log" 2>&1 \
+  || { echo "FAIL: rotated-CA run should still exit 0"; cat "${TMP}/r9b.log"; exit 1; }
+grep -q 'REFUSING zzz.solution.example' "${TMP}/r9b.log" \
+  || { echo "FAIL: changed fingerprint was NOT refused"; cat "${TMP}/r9b.log"; exit 1; }
+# The refused peer must drop out of the config entirely. Both peers federate on the
+# first run; after the rotation only the pinned one may remain. (Asserting on the
+# fingerprint itself would be wrong here - the stub gives every cert the same one.)
+[ "$(grep -c '<federateCA' "$D9/federation-extra.xml")" = "1" ] \
+  || { echo "FAIL: expected exactly 1 federateCA after refusal"; cat "$D9/federation-extra.xml"; exit 1; }
+grep -q 'federation-outgoing displayName="zzz.solution.example"' "$D9/federation-extra.xml" \
+  && { echo "FAIL: refused peer still has an outgoing connection"; exit 1; }
+
+# 10. Finding 1a: a configmap-pinned CA is authoritative and is never fetched over.
+grep -q 'pinned by configmap; not fetching' "${TMP}/r9a.log" \
+  || { echo "FAIL: pinned peer was fetched over"; cat "${TMP}/r9a.log"; exit 1; }
+# ...and rotating the *fetched* fingerprint must not disturb the pinned peer.
+grep -q 'REFUSING pinned-peer' "${TMP}/r9b.log" \
+  && { echo "FAIL: pinned peer wrongly subjected to TOFU check"; exit 1; }
+
+# 11. Finding 7: a broken identity degrades to federation-off, exit 0, no fragment,
+#     and a usable keystore is still left behind so TAK can start.
+D11="${TMP}/opt/tak/data/fed11"
+printf 'takserver-jks\n' > "${TMP}/opt/tak/data/certs/files/takserver.jks"
+rm -f "${TMP}/opt/tak/data/certs/files/fed-keystore.jks"
+run_fed "$D11" STUB_EKU="TLS Web Server Authentication" > "${TMP}/r11.log" 2>&1 \
+  || { echo "FAIL: degraded run must exit 0 so TAK still starts"; cat "${TMP}/r11.log"; exit 1; }
+grep -q 'Federation DISABLED' "${TMP}/r11.log" \
+  || { echo "FAIL: no degrade message"; cat "${TMP}/r11.log"; exit 1; }
+[ ! -f "$D11/federation-extra.xml" ] \
+  || { echo "FAIL: degraded run still wrote a federation fragment"; exit 1; }
+[ -s "${TMP}/opt/tak/data/certs/files/fed-keystore.jks" ] \
+  || { echo "FAIL: degraded run left no keystore - TAK would fail to start"; exit 1; }
+
+# 12. Finding 7, the case only the live server caught: an UNREADABLE cert made
+#     openssl fail, and `set -e` aborted before fatal() ever ran - so TAK died.
+#     A wrong EKU was not enough to reproduce it; this is.
+D12="${TMP}/opt/tak/data/fed12"
+rm -f "${TMP}/opt/tak/data/certs/files/fed-keystore.jks"
+run_fed "$D12" STUB_BAD_CERT=1 > "${TMP}/r12.log" 2>&1 \
+  || { echo "FAIL: unreadable cert must degrade, not abort"; cat "${TMP}/r12.log"; exit 1; }
+grep -q 'not a readable certificate' "${TMP}/r12.log" \
+  || { echo "FAIL: no diagnostic for unreadable cert"; cat "${TMP}/r12.log"; exit 1; }
+grep -q 'Federation DISABLED' "${TMP}/r12.log" \
+  || { echo "FAIL: did not degrade"; cat "${TMP}/r12.log"; exit 1; }
+[ -s "${TMP}/opt/tak/data/certs/files/fed-keystore.jks" ] \
+  || { echo "FAIL: no keystore left behind - TAK would fail to start"; exit 1; }
+
+echo "PASS: order, pinned peer, dial direction, group list, asymmetric in/out, self-exclusion, unreachable-peer tolerance, CA-rotation refused, pin honoured, degrade-not-die, unreadable-cert-degrades"


### PR DESCRIPTION
## Description
<!-- What changed and why? How were the changes tested? -->

TAK federation between two deployments' TAK servers does not work today. This PR makes
the image capable of it. The consumers are pvarki/opendefence-platform#87 (k8s) and
pvarki/docker-rasenmaeher-integration#272 (compose), both in review alongside this one. It is deliberately inert until something opts in: with no new
environment variables set and no fragment file present, the rendered `CoreConfig.xml`
is semantically identical to what this image produces now.

### Why it does not work today

Three separate things break it, and the first two are invisible from the logs on the
side that fails.

1. **The federation identity has no `clientAuth`.** Federation v2 is mutual TLS, and
   `TakFigClient` reads `<federation-server><tls>` for its *client* identity on outgoing
   connections, not just for the inbound listener. That element points at
   `takserver.jks`, which `firstrun_rm.sh` builds from the Let's Encrypt certificate.
   Let's Encrypt removed the `clientAuth` EKU from its default ACME profile on
   2026-02-11 and stopped issuing it entirely on 2026-07-08. Verified against a running
   deployment:

   ```
   $ openssl s_client -connect tak.<host>:9001 -alpn h2 </dev/null \
       | openssl x509 -noout -issuer -ext extendedKeyUsage
   issuer=C=US, O=Let's Encrypt, CN=YR1
   X509v3 Extended Key Usage:
       TLS Web Server Authentication
   ```

   No truststore change can fix that — the peer's `X509TrustManagerImpl.checkClientTrusted`
   rejects a serverAuth-only certificate, and that rejection is logged on the *peer*,
   while our side sees only a generic TLS alert.

2. **`fed-truststore.jks` was rebuilt from our own CAs on every start.** The two `cp`
   lines in `firstrun_rm.sh` sit *above* the `firstrun.done` early-exit, so they ran on
   every container start rather than only the first. Any peer CA added to that store was
   silently discarded on the next restart, and federation came back trusting nobody.

3. **Nothing survived a restart.** `start-tak.sh` regenerates `CoreConfig.xml` from the
   template on every container start, so `<federate>` entries written by the admin UI or
   by auto-discovery (`setAndSaveFederation()`) are destroyed. The template is the only
   durable place for federation configuration.

### What changed

**`scripts/firstrun_rm.sh`** — seed `fed-truststore.jks` only when it does not already
exist, and stop making it a copy of `truststore-root.jks`. Those two were the same file,
which is harmless until you federate: `truststore-root.jks` authenticates ATAK *clients*
on 8089, so a federation peer's CA landing in it would let that peer's unit mint users on
this server. They are now separate concerns and stay that way.

**`templates/CoreConfig.tpl`** — two hooks, one changed line and seven added:

- `TAK_FED_KEYSTORE_FILE` overrides the federation TLS keystore, so a deployment can
  federate on a private-CA identity while 8089 and 8443 keep the Let's Encrypt
  certificate that fielded clients already trust. Defaults to `certs/files/takserver.jks`.
- `TAK_FEDERATION_EXTRA_FILE` splices in a generated `<federation>` tail. The fragment
  owns everything between `</federation-server>` and `</federation>` because
  `CoreConfig.xsd` fixes the child order as `federation-outgoing*`, `fileFilter`,
  `federateCA*` — `fileFilter` is required and sits between the two elements an operator
  needs to add, so one splice point has to cover all three. Falls back to the stock
  `<fileFilter>` block when the file is absent.

**`scripts/federation-init.sh`** (new) — builds the federation keystore and peer trust,
and generates that fragment. Given a private-CA identity and a directory of peer CA PEMs
it produces `fed-keystore.jks`, adds the peers to `fed-truststore.jks`, and writes the
fragment. Idempotent: everything is rebuilt from scratch each run, so stale peers cannot
accumulate.

Details it enforces, each of which is a full afternoon to diagnose the hard way:

- **Exactly one key entry in the keystore.** `CoreConfig` pins `keymanager="SunX509"`,
  whose alias choice is by key algorithm and issuer, so a second entry makes it ambiguous.
- **The issuing chain is included.** TAK identifies a peer by `certArray[1]`
  (`FederationServer.java`), so a leaf-only keystore throws `ArrayIndexOutOfBounds`
  inside the interceptor and surfaces only as a generic `Status.INTERNAL`.
- **`<federateCA>` pins the intermediate, not the root.** Roots are frequently short-lived
  and re-issued, which changes their DER and therefore their SHA-256.
- **Exactly one side of each pair dials.** `FederationServer` raises
  `DuplicateFederateException` and the link flaps if both do, so the dialer is elected by
  comparing hostnames — a stable answer on both sides with no coordination.
- **The EKU is checked up front and fails loudly**, because otherwise the only evidence
  is in the peer's log.

### How this makes federation work

With the hooks in place a deployment sets one variable naming its peers. `federation-init.sh`
fetches each peer's CA, pins it by SHA-256, decides who dials whom, and writes the fragment;
`CoreConfig.tpl` splices it in on every container start, so the configuration is rebuilt
from scratch each time rather than restored from something a restart already destroyed.
`firstrun_rm.sh` no longer throws the peer CAs away in between.

### How it was tested

- Both template paths rendered with `gomplate` and validated against `CoreConfig.xsd`
  from the 5.8 distribution:

  ```
  out-default.xml  validates    # no env, no fragment -> unchanged behaviour
  out-fed.xml      validates    # federation-outgoing -> fileFilter -> federateCA
  ```

- `tests/federation/test-federation-init.sh` (new, wired into the existing `checks` job)
  covers XSD child order, dialer election, self-exclusion, group lists, asymmetric
  inbound/outbound mapping and an unreachable peer. It needs only bash, openssl and
  xmllint — no cluster, no network.
- Exercised between two live Deploy App deployments: mutual TLS on 9001 against the
  deployment CA, CoT crossing in both directions, and **verified across a pod restart** —
  identity came back with both EKUs, peer CA re-imported at the same SHA-256, dialer
  election reached the same answer, federate reconnected on its own.
- `prek run --all-files` green.

### Update: three security fixes (`8b8c1fa`)

A security review of this work found three defects, now fixed in this PR and re-verified
end to end on two live deployments.

**1. The `<federateCA>` fingerprint was not a pin.** It was computed from the PEM that had
just been downloaded, and recomputed from the network on every container start — weaker
than trust-on-first-use, which at least notices a change the second time. Anyone able to
pass ACME for a peer hostname could rotate us onto their CA at the next restart, with no
diff and no alert, and then read every local client's position and inject CoT. First-seen
fingerprints now persist and are compared; a change is refused.

The documented escape hatch was broken too: configmap-pinned CAs and fetched CAs shared a
filename namespace and the fetch ran second, so it overwrote the operator's pinned file —
and deleted it outright when the fetch failed. Pinned CAs are now authoritative.

**2. Token auth defaults off** (`TAK_FEDERATION_TOKEN_AUTH`). Port 9002 completed an
**anonymous TLS handshake** from the internet — no client certificate requested, unlike
9001 and 8089 — and token auth bypasses `fed-truststore.jks` and `<federateCA>` pinning
entirely. `allowTokenAuth="false"` does **not** gate the listener, only federates matched
by that CA. The XSD default is `false`; this template shipped `true`.

**3. A broken federation identity no longer takes TAK down.** `FED_STRICT` defaulted true,
so a bad cert failed the init container and dropped 8089 for every fielded client — an
optional feature wired as a hard dependency of the core service.

Worth calling out: **the first version of fix 3 did not work, and only the live server
showed it.** `set -e` aborted on `openssl` before `fatal()` was ever reached, so a corrupt
`tls.crt` still killed the container. The stubbed `openssl` in the unit test always
succeeded and could not reproduce it. The identity build is now a function invoked with
`if ! …` (which suspends `set -e` for the call), and the suite gained a `STUB_BAD_CERT`
case that reproduces the original failure. Tests: 7 → 11.

## User-Facing Changes
<!-- releasenote:start -->
### TAK server federation between deployments
TAK servers can now federate with each other, sharing situational awareness, chat and
missions across separate deployments. Federation uses its own certificate issued by the
deployment's own CA, so ATAK clients and the web interface are unaffected and keep working
exactly as before. Deployments that do not configure a peer see no change at all.
<!-- releasenote:end -->

## Anything Else You'd Like to Mention

- **Backwards compatible by construction.** `TAK_FED_KEYSTORE_FILE` defaults to today's
  value and `TAK_FEDERATION_EXTRA_FILE` defaults to a path that does not exist, so an
  existing deployment renders the same config it does now. The existing
  `compose_validations` job exercises exactly that path.
- The `firstrun_rm.sh` change is the one with real behavioural reach: `fed-truststore.jks`
  is no longer overwritten on restart. For a non-federating deployment the file is still
  seeded identically on first run, so the visible effect is nil.
- `scripts/disable_admin.sh` has no caller in this repo or in `python-tak-rmapi`. Not
  touched here, just noticed.
- The consuming side is a matching PR in `opendefence-platform`, which currently carries a
  fork of `CoreConfig.tpl` as a ConfigMap. Once this ships in an image tag that fork and
  its vendored copy of `federation-init.sh` both delete.


