### PR TITLE
CoT and HTTPS keystores

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion] # Remember to change the TAK_RELEASE tag in CI jobs as well
-current_version = "5.8.69+260823"
+current_version = "5.8.69+260912"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 ########################################################################
 ARG TEMURIN_VERSION="17"
 ARG TAK_RELEASE="5.8-RELEASE-69"
+ARG KW_PRODUCT_INIT_IMAGE="ghcr.io/pvarki/kraftwerk-helper-tool:1.4.0-260912"
+FROM ${KW_PRODUCT_INIT_IMAGE} AS product-init
 FROM pvarki/tak-server-dist:$TAK_RELEASE AS tak-files
 RUN mv /zips/takserver-docker-*.zip /tmp/takserver.zip
 
@@ -49,4 +51,5 @@ COPY templates /opt/templates
 COPY update /opt/tak/webcontent/update
 
 FROM install AS run
+COPY --from=product-init /kw_product_init /kw_product_init
 ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,37 @@ Build the distribution::
 Now you have the build artefacts in outputs -directory.
 
 
+CFSSL and HTTPS certificates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``/opt/scripts/firstrun_rm.sh`` initializes the product identity through RMAPI,
+which signs its CSR with CFSSL. It requests RSA explicitly because TAK 5.8 uses
+its global TLS key for RS256 JWT signing. No TAK Java classes are modified.
+
+Mount the same volume at ``/data/persistent`` in ``takinit`` and ``takrmapi``.
+The initializer owns the single-use CSR token in ``/pvarki/kraftwerk-init.json``;
+``takrmapi`` reuses the resulting ``private/mtlsclient.key`` and
+``public/mtlsclient.pem``. Existing RSA product credentials are reused. Older
+certificates with only client authentication are renewed through mTLS to obtain
+server authentication too. Deploy the corresponding RMAPI CFSSL profile update
+before this initializer.
+
+CoT on port 8089 uses ``/opt/tak/data/certs/files/takserver.jks`` with the CFSSL
+identity. HTTPS on port 8443 uses ``takserver-https.jks``, imported from
+``/le_certs/rasenmaeher/privkey.pem`` and ``fullchain.pem``. Set
+``TAK_HTTPS_KEYSTORE_FILENAME=/opt/tak/data/certs/files/takserver-https.jks``
+for all TAK processes; the integration compositions set this automatically.
+The API startup script also sets Spring's SSL keystore property because TAK's
+primary HTTPS connector ignores the per-connector keystore override.
+Both keystores use ``TAKSERVER_CERT_PASS`` / ``TAKSERVER_KEYSTORE_PASS``.
+Standalone initialization retains the original shared keystore default.
+
+Rerunning the initializer refreshes the keystores from their PEM files without
+regenerating the product key or reimporting the database. HTTPS certificate
+rotation therefore leaves CoT and JWT signing keys intact. CoT clients may use
+EC certificates. The truststores contain the CFSSL root and intermediate CAs.
+
+
 Versioning
 ^^^^^^^^^^
 

--- a/scripts/firstrun_rm.sh
+++ b/scripts/firstrun_rm.sh
@@ -1,131 +1,93 @@
 #!/usr/bin/env -S /bin/bash
+set -euo pipefail
 TR=/opt/tak
-CR=${TR}/certs
 
-TAK_SERVER_KEY_FILENAME="${TAK_SERVER_KEY_FILENAME:-/le_certs/rasenmaeher/privkey.pem}"
-TAK_SERVER_CERT_FILENAME="${TAK_SERVER_CERT_FILENAME:-/le_certs/rasenmaeher/fullchain.pem}"
+# CoT and TAK's built-in JWT signer share an RSA identity issued by CFSSL via RMAPI.
+TAK_SERVER_KEY_FILENAME="${TAK_SERVER_KEY_FILENAME:-/data/persistent/private/mtlsclient.key}"
+TAK_SERVER_CERT_FILENAME="${TAK_SERVER_CERT_FILENAME:-/data/persistent/public/mtlsclient.pem}"
+TAK_HTTPS_KEY_FILENAME="${TAK_HTTPS_KEY_FILENAME:-/le_certs/rasenmaeher/privkey.pem}"
+TAK_HTTPS_CERT_FILENAME="${TAK_HTTPS_CERT_FILENAME:-/le_certs/rasenmaeher/fullchain.pem}"
+TAK_HTTPS_KEYSTORE_FILENAME="${TAK_HTTPS_KEYSTORE_FILENAME:-/opt/tak/data/certs/files/takserver-https.jks}"
 TAKSERVER_KEYSTORE_PASS="${TAKSERVER_KEYSTORE_PASS:-takservercertpass}"
-
 RM_CERT_CHAIN_FILENAME="${RM_CERT_CHAIN_FILENAME:-/ca_public/ca_chain.pem}"
-
-# Secret to trusted certs java keystore
 KEYSTORE_PASS="${KEYSTORE_PASS:-takcacertpw}"
 
-# Symlink the log directory under data dir
-if [[ ! -d "${TR}/data/logs" ]];then
-  mkdir -p "${TR}/data/logs"
-fi
-if [[ ! -L "${TR}/logs"  ]];then
+mkdir -p "${TR}/data/logs" "${TR}/data/certs/files" /data/persistent
+if [[ ! -L "${TR}/logs" ]]; then
   ln -f -s "${TR}/data/logs/" "${TR}/logs"
 fi
-
-# Seed initial certificate data if necessary
-if [[ ! -d "${TR}/data/certs" ]];then
-  mkdir -p "${TR}/data/certs"
-fi
-# Move original certificate data and symlink to certificate data in data dir
-if [[ ! -L "${TR}/certs"  ]];then
-  mv ${TR}/certs ${TR}/certs.orig
+if [[ ! -L "${TR}/certs" ]]; then
+  mv "${TR}/certs" "${TR}/certs.orig"
   ln -f -s "${TR}/data/certs/" "${TR}/certs"
 fi
 
-TAK_SERVER_HOSTNAME="$(cat /pvarki/kraftwerk-init.json | jq -r  .product.dns)"
-
-
-mkdir -p /opt/tak/data/certs/files
-pushd /opt/tak/data/certs/files >> /dev/null
-
-openssl list -providers 2>&1 | grep "\(invalid command\|unknown option\)" >/dev/null
-if [ $? -ne 0 ] ; then
-  echo "Using legacy provider"
-  LEGACY_PROVIDER="-legacy"
+TAK_SERVER_HOSTNAME="$(jq -er .product.dns /pvarki/kraftwerk-init.json)"
+# Development DNS resolves to loopback; reach the published RMAPI through the host.
+if [[ "$(jq -r .rasenmaeher.init.base_uri /pvarki/kraftwerk-init.json)" == *localmaeher.dev.pvarki.fi* ]]; then
+  GW_IP="$(getent ahostsv4 host.docker.internal | awk '$2 == "STREAM" {print $1; exit}')"
+  test -n "${GW_IP}"
+  echo "${GW_IP} localmaeher.dev.pvarki.fi mtls.localmaeher.dev.pvarki.fi" >> /etc/hosts
 fi
 
-
-echo "(re)Add TLS keys to keystore"
-# We have to do this pkcs12 song and dance because keytool can't import private keys directly
-# Create takserver.p12 using certificates from RM
-openssl pkcs12 ${LEGACY_PROVIDER} -export -out takserver.p12 \
-  -inkey "${TAK_SERVER_KEY_FILENAME}" \
-  -in "${TAK_SERVER_CERT_FILENAME}" \
-  -name "${TAK_SERVER_HOSTNAME}" \
-  -passout pass:${TAKSERVER_KEYSTORE_PASS}
-
-# Remove the old key (if exists)
-keytool -delete \
-  -alias "${TAK_SERVER_HOSTNAME}" \
-  -keystore takserver.jks \
-  -storepass "${TAKSERVER_KEYSTORE_PASS}"
-# Create the Java keystore and import takserver.p12
-keytool -importkeystore -srcstoretype PKCS12 \
-  -destkeystore takserver.jks \
-  -srckeystore takserver.p12 \
-  -alias "${TAK_SERVER_HOSTNAME}" \
-  -srcstorepass "${TAKSERVER_KEYSTORE_PASS}" \
-  -deststorepass "${TAKSERVER_KEYSTORE_PASS}" \
-  -destkeypass "${TAKSERVER_KEYSTORE_PASS}"
-
-# Put the CA certs one-by-one (can't import full chains in one go) to the truststore
-# Remove the old root key (if exists)
-keytool -delete \
-  -alias "RM_Root" \
-  -keystore takserver-truststore.jks \
-  -storepass ${KEYSTORE_PASS}
-# Add root key
-keytool -noprompt -import -trustcacerts \
-  -file "/ca_public/root_ca.pem" \
-  -alias "RM_Root" \
-  -keystore takserver-truststore.jks \
-  -storepass ${KEYSTORE_PASS}
-
-# Remove the old intermediate key (if exists)
-keytool -delete \
-  -alias "RM_Intermediate" \
-  -keystore takserver-truststore.jks \
-  -storepass ${KEYSTORE_PASS}
-# Add intermediate key
-keytool -noprompt -import -trustcacerts \
-  -file "/ca_public/intermediate_ca.pem" \
-  -alias "RM_Intermediate" \
-  -keystore takserver-truststore.jks \
-  -storepass ${KEYSTORE_PASS}
-
-if [[ -f "/ca_public/miniwerk_ca.pem" ]];then
-  # Remove the old key (if exists)
-  keytool -delete \
-    -alias "MW_Root" \
-    -keystore takserver-truststore.jks \
-    -storepass ${KEYSTORE_PASS}
-  keytool -noprompt -import -trustcacerts \
-    -file /ca_public/miniwerk_ca.pem \
-    -alias "MW_Root" \
-    -keystore takserver-truststore.jks \
-    -storepass ${KEYSTORE_PASS}
+# Reuse the product identity on restart, including identities created by older takrmapi.
+# The manifest's CSR token must never be consumed independently by both containers.
+if [[ ! -s /data/persistent/public/mtlsclient.pem ]]; then
+  /kw_product_init init --keytype RSA /pvarki/kraftwerk-init.json
 fi
+openssl rsa -in "${TAK_SERVER_KEY_FILENAME}" -check -noout >/dev/null
+if ! openssl verify -CAfile "${RM_CERT_CHAIN_FILENAME}" -purpose sslserver \
+    -verify_hostname "${TAK_SERVER_HOSTNAME}" "${TAK_SERVER_CERT_FILENAME}"; then
+  # Older product certificates only had clientAuth. Reissue using the same key
+  # and mTLS credentials, without consuming the bootstrap token again.
+  /kw_product_init renew /pvarki/kraftwerk-init.json
+  openssl verify -CAfile "${RM_CERT_CHAIN_FILENAME}" -purpose sslserver \
+    -verify_hostname "${TAK_SERVER_HOSTNAME}" "${TAK_SERVER_CERT_FILENAME}"
+fi
+date -u +"%Y%m%dT%H%M" >/data/persistent/firstrun.done
 
-# fed-truststore.jks is needed, copy takserver-truststore.jks
-# TODO what are the names of truststores that we actually need???
-cp -v /opt/tak/data/certs/files/takserver-truststore.jks /opt/tak/data/certs/files/fed-truststore.jks
-cp -v /opt/tak/data/certs/files/takserver-truststore.jks /opt/tak/data/certs/files/truststore-root.jks
+cert_work="$(mktemp -d "${TR}/data/certs/files/.init-XXXXXX")"
+trap 'rm -rf "$cert_work"' EXIT
 
-popd >> /dev/null
+import_identity() {
+  local name="$1" key="$2" certificate="$3" destination="$4"
+  # Build fresh stores so stale aliases cannot affect TAK's JWT key selection.
+  openssl pkcs12 -export -out "${cert_work}/${name}.p12" \
+    -inkey "${key}" -in "${certificate}" -name "${TAK_SERVER_HOSTNAME}" \
+    -passout "pass:${TAKSERVER_KEYSTORE_PASS}"
+  keytool -noprompt -importkeystore -srcstoretype PKCS12 -deststoretype JKS \
+    -destkeystore "${cert_work}/${name}.jks" -srckeystore "${cert_work}/${name}.p12" \
+    -alias "${TAK_SERVER_HOSTNAME}" -srcstorepass "${TAKSERVER_KEYSTORE_PASS}" \
+    -deststorepass "${TAKSERVER_KEYSTORE_PASS}" -destkeypass "${TAKSERVER_KEYSTORE_PASS}"
+  chmod 600 "${cert_work}/${name}.jks"
+  mv "${cert_work}/${name}.jks" "${destination}"
+}
 
-if [ -f /opt/tak/data/firstrun.done ]
-then
+import_identity cot "${TAK_SERVER_KEY_FILENAME}" "${TAK_SERVER_CERT_FILENAME}" \
+  "${TR}/data/certs/files/takserver.jks"
+import_identity https "${TAK_HTTPS_KEY_FILENAME}" "${TAK_HTTPS_CERT_FILENAME}" \
+  "${TAK_HTTPS_KEYSTORE_FILENAME}"
+
+for ca in root_ca intermediate_ca; do
+  keytool -noprompt -importcert -trustcacerts -storetype JKS \
+    -file "/ca_public/${ca}.pem" -alias "${ca}" \
+    -keystore "${cert_work}/truststore.jks" -storepass "${KEYSTORE_PASS}"
+done
+# Client identities on TAK and federation connections are issued by CFSSL.
+cp "${cert_work}/truststore.jks" "${TR}/data/certs/files/truststore-root.jks"
+cp "${cert_work}/truststore.jks" "${TR}/data/certs/files/fed-truststore.jks"
+mv "${cert_work}/truststore.jks" "${TR}/data/certs/files/takserver-truststore.jks"
+
+if [[ -f "${TR}/data/firstrun.done" ]]; then
   echo "First run already done, not importing database"
   exit 0
 fi
 
-
-set -e
 echo "Wait for postgres"
-WAITFORIT_TIMEOUT=60 /usr/bin/wait-for-it.sh ${POSTGRES_ADDRESS}:5432 -- true
+WAITFORIT_TIMEOUT=60 /usr/bin/wait-for-it.sh "${POSTGRES_ADDRESS}:5432" -- true
 echo "Init db"
-# This requires postgres superuser privileges which we do not want to actually give to tak containers
-# java -jar ${TR}/db-utils/SchemaManager.jar -url jdbc:postgresql://${POSTGRES_ADDRESS}:5432/${POSTGRES_DB} -user ${POSTGRES_SUPERUSER} -password ${POSTGRES_SUPER_PASSWORD} upgrade
-# First import base SQL file to get base migration state
-PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -h ${POSTGRES_ADDRESS} -U ${POSTGRES_USER} ${POSTGRES_DB} --single-transaction --file /opt/scripts/takdb_base.sql
-# Then if there are any un-applied migrations apply them.
-java -jar ${TR}/db-utils/SchemaManager.jar -url jdbc:postgresql://${POSTGRES_ADDRESS}:5432/${POSTGRES_DB} -user ${POSTGRES_USER} -password ${POSTGRES_PASSWORD} upgrade
-
-date -u +"%Y%m%dT%H%M" >/opt/tak/data/firstrun.done
+PGPASSWORD="${POSTGRES_PASSWORD}" psql -v ON_ERROR_STOP=1 -h "${POSTGRES_ADDRESS}" \
+  -U "${POSTGRES_USER}" "${POSTGRES_DB}" --single-transaction --file /opt/scripts/takdb_base.sql
+java -jar "${TR}/db-utils/SchemaManager.jar" \
+  -url "jdbc:postgresql://${POSTGRES_ADDRESS}:5432/${POSTGRES_DB}" \
+  -user "${POSTGRES_USER}" -password "${POSTGRES_PASSWORD}" upgrade
+date -u +"%Y%m%dT%H%M" >"${TR}/data/firstrun.done"

--- a/scripts/start-tak.sh
+++ b/scripts/start-tak.sh
@@ -55,6 +55,11 @@ elif [ $1 = "config" ]; then
     java -jar -Xmx${CONFIG_MAX_HEAP}m -Dspring.profiles.active=config takserver.war
 elif [ $1 = "api" ]; then
     echo "Starting TAK API"
+    # TAK applies CoreConfig keystore overrides only to additional connectors.
+    # Its primary HTTPS connector reads Spring's SSL properties instead.
+    if [[ -n "${TAK_HTTPS_KEYSTORE_FILENAME:-}" ]]; then
+        export SERVER_SSL_KEY_STORE="${TAK_HTTPS_KEYSTORE_FILENAME}"
+    fi
     java -jar -Xmx${API_MAX_HEAP}m -Dspring.profiles.active=api,consolelog -Dkeystore.pkcs12.legacy takserver.war
 elif [ $1 = "retention" ]; then
     echo "Starting TAK Retention"

--- a/templates/CoreConfig.tpl
+++ b/templates/CoreConfig.tpl
@@ -11,7 +11,10 @@
         <connector port="8446" clientAuth="false" _name="cert_https"/>
         -->
         <!-- Disable webtak and non-admin user interfaces -->
-        <connector port="8443" _name="https" enableWebtak="{{getenv "WEBTAK_ENABLE" "false"}}" enableNonAdminUI="false" />
+        <connector port="8443" _name="https" enableWebtak="{{getenv "WEBTAK_ENABLE" "false"}}" enableNonAdminUI="false"
+            keystore="JKS"
+            keystoreFile="{{getenv "TAK_HTTPS_KEYSTORE_FILENAME" "/opt/tak/data/certs/files/takserver.jks"}}"
+            keystorePass="{{.Env.TAKSERVER_CERT_PASS}}" />
     </network>
 {{if getenv "LDAP_BIND_PASSWORD" ""}}
     <auth default="ldap" x509groups="true" x509addAnonymous="false">


### PR DESCRIPTION
## Description

Use separate keystores for CoT/"main" TLS (CoT etc) and https.

Mainly because the main TLS can only use RSA keys.

## User-Facing Changes

This further allows using a cert signed by our internal CA for TAK federation (which cannot and must not use LE certs).

## Anything Else You'd Like to Mention

  - Refs https://github.com/pvarki/docker-atak-server/issues/128
  - depends on https://github.com/pvarki/python-rasenmaeher-api/pull/182
  - Depends on https://github.com/pvarki/golang-kraftwerk-init-helper-cli/pull/10
