### PR TITLE
Add CoT listener without archiving on port 8090

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion] # Remember to change the TAK_RELEASE tag in CI jobs as well
-current_version = "5.8.69+260912"
+current_version = "5.8.69+2609121715"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - taknet
     ports:
       - '8089:8089'
+      - '8090:8090'
       - '8443:8443'
     command: ./opt/scripts/start-tak.sh config
     healthcheck:

--- a/templates/CoreConfig.tpl
+++ b/templates/CoreConfig.tpl
@@ -4,6 +4,7 @@
         xsi:schemaLocation="/opt/tak/CoreConfig.xsd">
     <network multicastTTL="5">
         <input _name="stdssl" protocol="tls" port="8089" coreVersion="2"/>
+        <input _name="stdssl-noarchive" protocol="tls" port="8090" coreVersion="2" archive="false"/>
 
         <!-- default web connectors
         <connector port="8443" _name="https"/>


### PR DESCRIPTION
## Description

Add CoT port 8090 with archiving disabled.

## User-Facing Changes

Users can use 8090 to ingest high-volume ephemeral data.

## Anything Else You'd Like to Mention

  - fixes https://github.com/pvarki/docker-atak-server/issues/132